### PR TITLE
Add email deployments, placements, and line items

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,14 @@ The following models _cannot_ be soft-deleted when... (note: by "active" we mean
 **Publisher**
 - An active Placement exists with `Placement.publisherId` equal to `Publisher.id`
 - An active Topic exists with `Topic.publisherId` equal to `Publisher.id`
+- An active Story exists with `Story.publisherId` equal to `Publisher.id`
+- An active Email Deployment exists with `EmailDeployment.publisherId` equal to `Publisher.id`
+
+**Email Deployment**
+- An active Email Placement exists with `EmailPlacement.deploymentId` equal to `EmailDeployment.id`
+
+**Email Placement**
+- An active Campaign exists with `Campaign.criteria.emailPlacementId` equal to `EmailPlacement.id`
 
 **Placement**
 - An active Campaign exists with `Campaign.criteria.placementIds` containing `Placement.id`

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "body-parser": "^1.18.2",
     "cors": "^2.8.4",
     "crawler-user-agents": "https://github.com/monperrus/crawler-user-agents.git#master",
+    "dayjs": "^1.9.7",
     "deep-assign": "^2.0.0",
     "deepmerge": "^2.1.0",
     "elasticsearch": "^15.0.0",

--- a/src/dayjs.js
+++ b/src/dayjs.js
@@ -1,0 +1,11 @@
+const dayjs = require('dayjs');
+const advancedFormat = require('dayjs/plugin/advancedFormat');
+const timezone = require('dayjs/plugin/timezone');
+const utc = require('dayjs/plugin/utc');
+
+dayjs
+  .extend(utc)
+  .extend(timezone)
+  .extend(advancedFormat);
+
+module.exports = dayjs;

--- a/src/graph/definitions/campaign.graphql
+++ b/src/graph/definitions/campaign.graphql
@@ -63,6 +63,7 @@ type Campaign implements UserAttribution & Timestampable {
   paused: Boolean!
   requiredCreatives: Int!
   publishers(pagination: PaginationInput = {}, sort: PublisherSortInput = {}): PublisherConnection!
+  emailLineItems(pagination: PaginationInput = {}, sort: EmailLineItemSortInput = {}): EmailLineItemConnection!
   url: String
   primaryImage: Image
   creatives: [CampaignCreative]

--- a/src/graph/definitions/email-deployment.graphql
+++ b/src/graph/definitions/email-deployment.graphql
@@ -20,6 +20,7 @@ enum EmailDeploymentSortField {
 type EmailDeployment implements UserAttribution & Timestampable {
   id: String!
   name: String!
+  fullName: String!
   publisher: Publisher!
   placements(pagination: PaginationInput = {}, sort: EmailPlacementSortInput = {}): EmailPlacementConnection!
 

--- a/src/graph/definitions/email-deployment.graphql
+++ b/src/graph/definitions/email-deployment.graphql
@@ -1,0 +1,60 @@
+type Query {
+  allEmailDeployments(pagination: PaginationInput = {}, sort: EmailDeploymentSortInput = {}): EmailDeploymentConnection!
+  searchEmailDeployments(pagination: PaginationInput = {}, phrase: String!): EmailDeploymentConnection!
+  autocompleteEmailDeployments(pagination: PaginationInput = {}, phrase: String!): EmailDeploymentConnection!
+  emailDeployment(input: ModelIdInput!): EmailDeployment!
+}
+
+type Mutation {
+  createEmailDeployment(input: CreateEmailDeploymentInput!): EmailDeployment!
+  deleteEmailDeployment(input: ModelIdInput!): String!
+  updateEmailDeployment(input: UpdateEmailDeploymentInput!): EmailDeployment!
+}
+
+enum EmailDeploymentSortField {
+  name
+  createdAt
+  updatedAt
+}
+
+type EmailDeployment implements UserAttribution & Timestampable {
+  id: String!
+  name: String!
+  publisher: Publisher!
+  placements(pagination: PaginationInput = {}, sort: EmailPlacementSortInput = {}): EmailPlacementConnection!
+
+  updatedAt: Date
+  createdAt: Date
+  createdBy: User!
+  updatedBy: User!
+}
+
+type EmailDeploymentConnection {
+  totalCount: Int!
+  edges: [EmailDeploymentEdge]!
+  pageInfo: PageInfo!
+}
+
+type EmailDeploymentEdge {
+  node: EmailDeployment!
+  cursor: Cursor!
+}
+
+input EmailDeploymentSortInput {
+  field: EmailDeploymentSortField! = createdAt
+  order: Int! = -1
+}
+
+input CreateEmailDeploymentInput {
+  payload: EmailDeploymentPayloadInput!
+}
+
+input EmailDeploymentPayloadInput {
+  name: String!
+  publisherId: String!
+}
+
+input UpdateEmailDeploymentInput {
+  id: String!
+  payload: EmailDeploymentPayloadInput!
+}

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -1,5 +1,6 @@
 type Mutation {
   createEmailLineItem(input: CreateEmailLineItemMutationInput!): EmailLineItem!
+  deleteEmailLineItem(input: ModelIdInput!): String!
 }
 enum EmailLineItemSortField {
   createdAt

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -44,7 +44,7 @@ type EmailLineItem implements UserAttribution & Timestampable {
 }
 
 type EmailLineItemDates {
-  type: EmailLineItemDateTypeEnum
+  type: EmailLineItemDateTypeEnum!
   start: Date
   end: Date
   days: [Date]!

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -6,6 +6,7 @@ type Mutation {
 }
 
 enum EmailLineItemSortField {
+  name
   createdAt
   updatedAt
 }
@@ -26,6 +27,7 @@ enum EmailLineItemStatusEnum {
 
 type EmailLineItem implements UserAttribution & Timestampable {
   id: String!
+  name: String!
   campaign: Campaign!
   placement: EmailPlacement!
   dates: EmailLineItemDates!
@@ -60,6 +62,7 @@ type EmailLineItemEdge {
 }
 
 input CreateEmailLineItemMutationInput {
+  name: String!
   campaignId: String!
   emailPlacementId: String!
 }

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -5,6 +5,8 @@ type Query {
 type Mutation {
   createEmailLineItem(input: CreateEmailLineItemMutationInput!): EmailLineItem!
   deleteEmailLineItem(input: ModelIdInput!): String!
+
+  emailLineItemDetails(input: EmailLineItemDetailsMutationInput!): EmailLineItem!
   emailLineItemDateDays(input: EmailLineItemDateDaysMutationInput): EmailLineItem!
   emailLineItemDateRange(input: EmailLineItemDateRangeMutationInput): EmailLineItem!
 }
@@ -89,6 +91,12 @@ input EmailLineItemDateRangeMutationInput {
   id: String!
   start: Date!
   end: Date!
+}
+
+input EmailLineItemDetailsMutationInput {
+  id: String!
+  name: String!
+  emailPlacementId: String!
 }
 
 input EmailLineItemSortInput {

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -70,6 +70,14 @@ input CreateEmailLineItemMutationInput {
   name: String!
   campaignId: String!
   emailPlacementId: String!
+  dates: CreateEmailLineItemDatesInput!
+}
+
+input CreateEmailLineItemDatesInput {
+  type: EmailLineItemDateTypeEnum!
+  start: Date
+  end: Date
+  days: [Date]
 }
 
 input EmailLineItemDateDaysMutationInput {

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -1,3 +1,7 @@
+type Query {
+  emailLineItem(input: ModelIdInput!): EmailLineItem!
+}
+
 type Mutation {
   createEmailLineItem(input: CreateEmailLineItemMutationInput!): EmailLineItem!
   deleteEmailLineItem(input: ModelIdInput!): String!

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -1,7 +1,10 @@
 type Mutation {
   createEmailLineItem(input: CreateEmailLineItemMutationInput!): EmailLineItem!
   deleteEmailLineItem(input: ModelIdInput!): String!
+  emailLineItemDateDays(input: EmailLineItemDateDaysMutationInput): EmailLineItem!
+  emailLineItemDateRange(input: EmailLineItemDateRangeMutationInput): EmailLineItem!
 }
+
 enum EmailLineItemSortField {
   createdAt
   updatedAt
@@ -59,6 +62,17 @@ type EmailLineItemEdge {
 input CreateEmailLineItemMutationInput {
   campaignId: String!
   emailPlacementId: String!
+}
+
+input EmailLineItemDateDaysMutationInput {
+  id: String!
+  days: [Date!]!
+}
+
+input EmailLineItemDateRangeMutationInput {
+  id: String!
+  start: Date!
+  end: Date!
 }
 
 input EmailLineItemSortInput {

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -1,3 +1,6 @@
+type Mutation {
+  createEmailLineItem(input: CreateEmailLineItemMutationInput!): EmailLineItem!
+}
 enum EmailLineItemSortField {
   createdAt
   updatedAt
@@ -50,6 +53,11 @@ type EmailLineItemConnection {
 type EmailLineItemEdge {
   node: EmailLineItem!
   cursor: Cursor!
+}
+
+input CreateEmailLineItemMutationInput {
+  campaignId: String!
+  emailPlacementId: String!
 }
 
 input EmailLineItemSortInput {

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -1,0 +1,58 @@
+enum EmailLineItemSortField {
+  createdAt
+  updatedAt
+}
+
+enum EmailLineItemDateTypeEnum {
+  range
+  days
+}
+
+enum EmailLineItemStatusEnum {
+  Deleted
+  Finished
+  Incomplete
+  Paused
+  Running
+  Scheduled
+}
+
+type EmailLineItem implements UserAttribution & Timestampable {
+  id: String!
+  campaign: Campaign!
+  placement: EmailPlacement!
+  dates: EmailLineItemDates!
+
+  status: EmailLineItemStatusEnum!
+  paused: Boolean!
+  ready: Boolean!
+  deleted: Boolean!
+
+  updatedAt: Date
+  createdAt: Date
+  createdBy: User!
+  updatedBy: User!
+}
+
+type EmailLineItemDates {
+  type: EmailLineItemDateTypeEnum
+  start: Date
+  end: Date
+  days: [Date]!
+}
+
+type EmailLineItemConnection {
+  totalCount: Int!
+  edges: [EmailLineItemEdge]!
+  pageInfo: PageInfo!
+}
+
+type EmailLineItemEdge {
+  node: EmailLineItem!
+  cursor: Cursor!
+}
+
+input EmailLineItemSortInput {
+  field: EmailLineItemSortField! = createdAt
+  order: Int! = -1
+}

--- a/src/graph/definitions/email-line-item.graphql
+++ b/src/graph/definitions/email-line-item.graphql
@@ -37,6 +37,7 @@ type EmailLineItem implements UserAttribution & Timestampable {
   dates: EmailLineItemDates!
 
   status: EmailLineItemStatusEnum!
+  requires: String
   paused: Boolean!
   ready: Boolean!
   deleted: Boolean!

--- a/src/graph/definitions/email-placement.graphql
+++ b/src/graph/definitions/email-placement.graphql
@@ -1,0 +1,31 @@
+enum EmailPlacementSortField {
+  name
+  createdAt
+  updatedAt
+}
+
+type EmailPlacement implements UserAttribution & Timestampable {
+  id: String!
+  name: String
+  deployment: EmailDeployment!
+  updatedAt: Date
+  createdAt: Date
+  createdBy: User!
+  updatedBy: User!
+}
+
+type EmailPlacementConnection {
+  totalCount: Int!
+  edges: [EmailPlacementEdge]!
+  pageInfo: PageInfo!
+}
+
+type EmailPlacementEdge {
+  node: EmailPlacement!
+  cursor: Cursor!
+}
+
+input EmailPlacementSortInput {
+  field: EmailPlacementSortField! = createdAt
+  order: Int! = -1
+}

--- a/src/graph/definitions/email-placement.graphql
+++ b/src/graph/definitions/email-placement.graphql
@@ -19,7 +19,8 @@ enum EmailPlacementSortField {
 
 type EmailPlacement implements UserAttribution & Timestampable {
   id: String!
-  name: String
+  name: String!
+  fullName: String!
   emailDeployment: EmailDeployment!
   updatedAt: Date
   createdAt: Date

--- a/src/graph/definitions/email-placement.graphql
+++ b/src/graph/definitions/email-placement.graphql
@@ -1,3 +1,16 @@
+type Query {
+  allEmailPlacements(pagination: PaginationInput = {}, sort: EmailPlacementSortInput = {}): EmailPlacementConnection!
+  searchEmailPlacements(pagination: PaginationInput = {}, phrase: String!): EmailPlacementConnection!
+  autocompleteEmailPlacements(pagination: PaginationInput = {}, phrase: String!): EmailPlacementConnection!
+  emailPlacement(input: ModelIdInput!): EmailPlacement!
+}
+
+type Mutation {
+  createEmailPlacement(input: CreateEmailPlacementInput!): EmailPlacement!
+  updateEmailPlacement(input: UpdateEmailPlacementInput!): EmailPlacement!
+  deleteEmailPlacement(input: ModelIdInput!): String!
+}
+
 enum EmailPlacementSortField {
   name
   createdAt
@@ -7,7 +20,7 @@ enum EmailPlacementSortField {
 type EmailPlacement implements UserAttribution & Timestampable {
   id: String!
   name: String
-  deployment: EmailDeployment!
+  emailDeployment: EmailDeployment!
   updatedAt: Date
   createdAt: Date
   createdBy: User!
@@ -28,4 +41,18 @@ type EmailPlacementEdge {
 input EmailPlacementSortInput {
   field: EmailPlacementSortField! = createdAt
   order: Int! = -1
+}
+
+input EmailPlacementPayloadInput {
+  name: String
+  deploymentId: String!
+}
+
+input CreateEmailPlacementInput {
+  payload: EmailPlacementPayloadInput!
+}
+
+input UpdateEmailPlacementInput {
+  id: String!
+  payload: EmailPlacementPayloadInput!
 }

--- a/src/graph/definitions/index.graphql
+++ b/src/graph/definitions/index.graphql
@@ -4,6 +4,7 @@
 # import * from 'contact.graphql'
 # import * from 'dashboard.graphql'
 # import * from 'email-deployment.graphql'
+# import * from 'email-line-item.graphql'
 # import * from 'email-placement.graphql'
 # import * from 'image.graphql'
 # import * from 'placement.graphql'

--- a/src/graph/definitions/index.graphql
+++ b/src/graph/definitions/index.graphql
@@ -3,6 +3,8 @@
 # import * from 'campaign.graphql'
 # import * from 'contact.graphql'
 # import * from 'dashboard.graphql'
+# import * from 'email-deployment.graphql'
+# import * from 'email-placement.graphql'
 # import * from 'image.graphql'
 # import * from 'placement.graphql'
 # import * from 'publisher.graphql'

--- a/src/graph/definitions/publisher.graphql
+++ b/src/graph/definitions/publisher.graphql
@@ -27,6 +27,7 @@ type Publisher implements UserAttribution & Timestampable {
   topics(pagination: PaginationInput = {}, sort: TopicSortInput = {}): TopicConnection!
   placements(pagination: PaginationInput = {}, sort: PlacementSortInput = {}): PlacementConnection!
   campaigns(pagination: PaginationInput = {}, sort: CampaignSortInput = {}): CampaignConnection!
+  emailDeployments(pagination: PaginationInput = {}, sort: EmailDeploymentSortInput = {}): EmailDeploymentConnection!
   updatedAt: Date
   createdAt: Date
   createdBy: User!

--- a/src/graph/definitions/publisher.graphql
+++ b/src/graph/definitions/publisher.graphql
@@ -28,6 +28,7 @@ type Publisher implements UserAttribution & Timestampable {
   placements(pagination: PaginationInput = {}, sort: PlacementSortInput = {}): PlacementConnection!
   campaigns(pagination: PaginationInput = {}, sort: CampaignSortInput = {}): CampaignConnection!
   emailDeployments(pagination: PaginationInput = {}, sort: EmailDeploymentSortInput = {}): EmailDeploymentConnection!
+  emailPlacements(pagination: PaginationInput = {}, sort: EmailPlacementSortInput = {}): EmailPlacementConnection!
   updatedAt: Date
   createdAt: Date
   createdBy: User!

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -304,7 +304,7 @@ module.exports = {
         title: story.title ? story.title.slice(0, 75) : undefined,
         teaser: story.teaser ? story.teaser.slice(0, 255) : undefined,
         imageId: story.primaryImageId,
-        active: story.title && story.teaser && story.imageId,
+        active: Boolean(story.title && story.teaser && story.imageId),
       });
       await campaign.save();
 

--- a/src/graph/resolvers/campaign.js
+++ b/src/graph/resolvers/campaign.js
@@ -1,17 +1,20 @@
 const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
 const moment = require('moment');
-const Advertiser = require('../../models/advertiser');
 const CreativeService = require('../../services/campaign-creatives');
-const Campaign = require('../../models/campaign');
-const Story = require('../../models/story');
-const Contact = require('../../models/contact');
-const Publisher = require('../../models/publisher');
-const Image = require('../../models/image');
-const Placement = require('../../models/placement');
-const User = require('../../models/user');
 const analytics = require('../../services/analytics');
 const campaignDelivery = require('../../services/campaign-delivery');
 const contactNotifier = require('../../services/contact-notifier');
+const {
+  Advertiser,
+  Campaign,
+  Story,
+  Contact,
+  Publisher,
+  Image,
+  Placement,
+  User,
+  EmailLineItem,
+} = require('../../models');
 
 const getNotifyDefaults = async (advertiserId, user) => {
   const advertiser = await Advertiser.strictFindById(advertiserId);
@@ -57,6 +60,10 @@ module.exports = {
       const publisherIds = await Placement.distinct('publisherId', { _id: { $in: placementIds }, deleted: false });
       const criteria = { _id: { $in: publisherIds } };
       return Publisher.paginate({ pagination, criteria, sort });
+    },
+    emailLineItems: async (campaign, { pagination, sort }) => {
+      const criteria = { campaignId: campaign.id };
+      return EmailLineItem.paginate({ pagination, criteria, sort });
     },
     metrics: campaign => analytics.retrieveMetrics({ cid: campaign._id }),
     reports: campaign => campaign,

--- a/src/graph/resolvers/email-deployment.js
+++ b/src/graph/resolvers/email-deployment.js
@@ -1,6 +1,7 @@
 const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
 const userAttributionFields = require('./user-attribution');
 const EmailDeployment = require('../../models/email-deployment');
+const EmailPlacement = require('../../models/email-placement');
 const Publisher = require('../../models/publisher');
 
 module.exports = {
@@ -9,6 +10,10 @@ module.exports = {
    */
   EmailDeployment: {
     publisher: ({ publisherId }) => Publisher.findById(publisherId),
+    placements: async (deployment, { pagination, sort }) => {
+      const criteria = { deploymentId: deployment.id, deleted: false };
+      return EmailPlacement.paginate({ criteria, pagination, sort });
+    },
     ...userAttributionFields,
   },
 

--- a/src/graph/resolvers/email-deployment.js
+++ b/src/graph/resolvers/email-deployment.js
@@ -1,0 +1,100 @@
+const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
+const userAttributionFields = require('./user-attribution');
+const EmailDeployment = require('../../models/email-deployment');
+const Publisher = require('../../models/publisher');
+
+module.exports = {
+  /**
+   *
+   */
+  EmailDeployment: {
+    publisher: ({ publisherId }) => Publisher.findById(publisherId),
+    ...userAttributionFields,
+  },
+
+  /**
+   *
+   */
+  EmailDeploymentConnection: paginationResolvers.connection,
+
+  /**
+   *
+   */
+  Mutation: {
+    /**
+     *
+     */
+    createEmailDeployment: (_, { input }, { auth }) => {
+      auth.check();
+      const { payload } = input;
+      const deployment = new EmailDeployment(payload);
+      deployment.setUserContext(auth.user);
+      return deployment.save();
+    },
+
+    /**
+     *
+     */
+    deleteEmailDeployment: async (_, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const deployment = await EmailDeployment.strictFindActiveById(id);
+      deployment.setUserContext(auth.user);
+      await deployment.softDelete();
+      return 'ok';
+    },
+
+    /**
+     *
+     */
+    updateEmailDeployment: async (_, { input }, { auth }) => {
+      auth.check();
+      const { id, payload } = input;
+      const deployment = await EmailDeployment.strictFindActiveById(id);
+      deployment.setUserContext(auth.user);
+      deployment.set(payload);
+      return deployment.save();
+    },
+  },
+
+  /**
+   *
+   */
+  Query: {
+    /**
+     *
+     */
+    allEmailDeployments: (_, { pagination, sort }, { auth }) => {
+      auth.check();
+      const criteria = { deleted: false };
+      return EmailDeployment.paginate({ criteria, pagination, sort });
+    },
+
+    /**
+     *
+     */
+    autocompleteEmailDeployments: (_, { pagination, phrase }, { auth }) => {
+      auth.check();
+      const filter = { term: { deleted: false } };
+      return EmailDeployment.autocomplete(phrase, { pagination, filter });
+    },
+
+    /**
+     *
+     */
+    emailDeployment: (_, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      return EmailDeployment.strictFindActiveById(id);
+    },
+
+    /**
+     *
+     */
+    searchEmailDeployments: (_, { pagination, phrase }, { auth }) => {
+      auth.check();
+      const filter = { term: { deleted: false } };
+      return EmailDeployment.search(phrase, { pagination, filter });
+    },
+  },
+};

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -111,6 +111,21 @@ module.exports = {
       });
       return doc.save();
     },
+
+    /**
+     *
+     */
+    emailLineItemDetails: async (_, { input }, { auth }) => {
+      auth.check();
+      const { id, name, emailPlacementId } = input;
+      const doc = await EmailLineItem.strictFindActiveById(id);
+      doc.setUserContext(auth.user);
+      doc.set({
+        name,
+        emailPlacementId,
+      });
+      return doc.save();
+    },
   },
 
   /**

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -1,6 +1,6 @@
 const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
 const userAttributionFields = require('./user-attribution');
-const { Campaign, EmailPlacement } = require('../../models');
+const { Campaign, EmailLineItem, EmailPlacement } = require('../../models');
 
 module.exports = {
   /**
@@ -16,4 +16,20 @@ module.exports = {
    *
    */
   EmailLineItemConnection: paginationResolvers.connection,
+
+  /**
+   *
+   */
+  Mutation: {
+    /**
+     *
+     */
+    createEmailLineItem: (_, { input }, { auth }) => {
+      auth.check();
+      const { campaignId, emailPlacementId } = input;
+      const lineItem = new EmailLineItem({ campaignId, emailPlacementId });
+      lineItem.setUserContext(auth.user);
+      return lineItem.save();
+    },
+  },
 };

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -27,8 +27,37 @@ module.exports = {
      */
     createEmailLineItem: (_, { input }, { auth }) => {
       auth.check();
-      const { name, campaignId, emailPlacementId } = input;
-      const lineItem = new EmailLineItem({ name, campaignId, emailPlacementId });
+      const {
+        name,
+        campaignId,
+        emailPlacementId,
+        dates,
+      } = input;
+
+      const {
+        type,
+        start,
+        end,
+        days,
+      } = dates;
+
+      const doc = {
+        name,
+        campaignId,
+        emailPlacementId,
+        dates: { type },
+      };
+
+      if (type === 'range') {
+        if (!start || !end) throw new Error('You must provide a start and end date.');
+        doc.dates.start = start;
+        doc.dates.end = end;
+      }
+      if (type === 'days') {
+        if (!Array.isArray(days) || !days.length) throw new Error('You must provide an array of days.');
+        doc.dates.days = days;
+      }
+      const lineItem = new EmailLineItem(doc);
       lineItem.setUserContext(auth.user);
       return lineItem.save();
     },

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -31,5 +31,17 @@ module.exports = {
       lineItem.setUserContext(auth.user);
       return lineItem.save();
     },
+
+    /**
+     *
+     */
+    deleteEmailLineItem: async (_, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const lineItem = await EmailLineItem.strictFindActiveById(id);
+      lineItem.setUserContext(auth.user);
+      await lineItem.softDelete();
+      return 'ok';
+    },
   },
 };

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -26,8 +26,8 @@ module.exports = {
      */
     createEmailLineItem: (_, { input }, { auth }) => {
       auth.check();
-      const { campaignId, emailPlacementId } = input;
-      const lineItem = new EmailLineItem({ campaignId, emailPlacementId });
+      const { name, campaignId, emailPlacementId } = input;
+      const lineItem = new EmailLineItem({ name, campaignId, emailPlacementId });
       lineItem.setUserContext(auth.user);
       return lineItem.save();
     },

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -1,0 +1,19 @@
+const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
+const userAttributionFields = require('./user-attribution');
+const { Campaign, EmailPlacement } = require('../../models');
+
+module.exports = {
+  /**
+   *
+   */
+  EmailLineItem: {
+    campaign: ({ campaignId }) => Campaign.findById(campaignId),
+    placement: ({ emailPlacementId }) => EmailPlacement.findById(emailPlacementId),
+    ...userAttributionFields,
+  },
+
+  /**
+   *
+   */
+  EmailLineItemConnection: paginationResolvers.connection,
+};

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -9,6 +9,7 @@ module.exports = {
   EmailLineItem: {
     campaign: ({ campaignId }) => Campaign.findById(campaignId),
     placement: ({ emailPlacementId }) => EmailPlacement.findById(emailPlacementId),
+    requires: lineItem => lineItem.getRequirements(),
     ...userAttributionFields,
   },
 

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -82,4 +82,18 @@ module.exports = {
       return doc.save();
     },
   },
+
+  /**
+   *
+   */
+  Query: {
+    /**
+     *
+     */
+    emailLineItem: (_, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      return EmailLineItem.strictFindActiveById(id);
+    },
+  },
 };

--- a/src/graph/resolvers/email-line-item.js
+++ b/src/graph/resolvers/email-line-item.js
@@ -43,5 +43,43 @@ module.exports = {
       await lineItem.softDelete();
       return 'ok';
     },
+
+    /**
+     *
+     */
+    emailLineItemDateDays: async (_, { input }, { auth }) => {
+      auth.check();
+      const { id, days } = input;
+      const doc = await EmailLineItem.strictFindActiveById(id);
+      doc.setUserContext(auth.user);
+      doc.set({
+        dates: {
+          type: 'days',
+          days,
+          start: undefined,
+          end: undefined,
+        },
+      });
+      return doc.save();
+    },
+
+    /**
+     *
+     */
+    emailLineItemDateRange: async (_, { input }, { auth }) => {
+      auth.check();
+      const { id, start, end } = input;
+      const doc = await EmailLineItem.strictFindActiveById(id);
+      doc.setUserContext(auth.user);
+      doc.set({
+        dates: {
+          type: 'range',
+          days: undefined,
+          start,
+          end,
+        },
+      });
+      return doc.save();
+    },
   },
 };

--- a/src/graph/resolvers/email-placement.js
+++ b/src/graph/resolvers/email-placement.js
@@ -1,0 +1,100 @@
+const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
+const userAttributionFields = require('./user-attribution');
+const EmailDeployment = require('../../models/email-deployment');
+const EmailPlacement = require('../../models/email-placement');
+
+module.exports = {
+  /**
+   *
+   */
+  EmailPlacement: {
+    emailDeployment: ({ deploymentId }) => EmailDeployment.findById(deploymentId),
+    ...userAttributionFields,
+  },
+
+  /**
+   *
+   */
+  EmailPlacementConnection: paginationResolvers.connection,
+
+  /**
+   *
+   */
+  Mutation: {
+    /**
+     *
+     */
+    createEmailPlacement: (_, { input }, { auth }) => {
+      auth.check();
+      const { payload } = input;
+      const placement = new EmailPlacement(payload);
+      placement.setUserContext(auth.user);
+      return placement.save();
+    },
+
+    /**
+     *
+     */
+    deleteEmailPlacement: async (_, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      const placement = await EmailPlacement.strictFindActiveById(id);
+      placement.setUserContext(auth.user);
+      await placement.softDelete();
+      return 'ok';
+    },
+
+    /**
+     *
+     */
+    updateEmailPlacement: async (_, { input }, { auth }) => {
+      auth.check();
+      const { id, payload } = input;
+      const placement = await EmailPlacement.strictFindActiveById(id);
+      placement.setUserContext(auth.user);
+      placement.set(payload);
+      return placement.save();
+    },
+  },
+
+  /**
+   *
+   */
+  Query: {
+    /**
+     *
+     */
+    allEmailPlacements: (_, { pagination, sort }, { auth }) => {
+      auth.check();
+      const criteria = { deleted: false };
+      return EmailPlacement.paginate({ criteria, pagination, sort });
+    },
+
+    /**
+     *
+     */
+    autocompleteEmailPlacements: (_, { pagination, phrase }, { auth }) => {
+      auth.check();
+      const filter = { term: { deleted: false } };
+      return EmailPlacement.autocomplete(phrase, { pagination, filter });
+    },
+
+    /**
+     *
+     */
+    emailPlacement: (_, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      return EmailPlacement.strictFindActiveById(id);
+    },
+
+    /**
+     *
+     */
+    searchEmailPlacements: (_, { pagination, phrase }, { auth }) => {
+      auth.check();
+      const filter = { term: { deleted: false } };
+      return EmailPlacement.search(phrase, { pagination, filter });
+    },
+  },
+};

--- a/src/graph/resolvers/index.js
+++ b/src/graph/resolvers/index.js
@@ -9,6 +9,7 @@ const campaign = require('./campaign');
 const contact = require('./contact');
 const dashboard = require('./dashboard');
 const emailDeployment = require('./email-deployment');
+const emailPlacement = require('./email-placement');
 const image = require('./image');
 const placement = require('./placement');
 const publisher = require('./publisher');
@@ -25,6 +26,7 @@ module.exports = deepAssign(
   contact,
   dashboard,
   emailDeployment,
+  emailPlacement,
   image,
   placement,
   publisher,

--- a/src/graph/resolvers/index.js
+++ b/src/graph/resolvers/index.js
@@ -8,6 +8,7 @@ const advertiser = require('./advertiser');
 const campaign = require('./campaign');
 const contact = require('./contact');
 const dashboard = require('./dashboard');
+const emailDeployment = require('./email-deployment');
 const image = require('./image');
 const placement = require('./placement');
 const publisher = require('./publisher');
@@ -23,6 +24,7 @@ module.exports = deepAssign(
   campaign,
   contact,
   dashboard,
+  emailDeployment,
   image,
   placement,
   publisher,

--- a/src/graph/resolvers/index.js
+++ b/src/graph/resolvers/index.js
@@ -9,6 +9,7 @@ const campaign = require('./campaign');
 const contact = require('./contact');
 const dashboard = require('./dashboard');
 const emailDeployment = require('./email-deployment');
+const emailLineItem = require('./email-line-item');
 const emailPlacement = require('./email-placement');
 const image = require('./image');
 const placement = require('./placement');
@@ -26,6 +27,7 @@ module.exports = deepAssign(
   contact,
   dashboard,
   emailDeployment,
+  emailLineItem,
   emailPlacement,
   image,
   placement,

--- a/src/graph/resolvers/publisher.js
+++ b/src/graph/resolvers/publisher.js
@@ -3,6 +3,7 @@ const userAttributionFields = require('./user-attribution');
 const AnalyticsPlacement = require('../../models/analytics/placement');
 const Campaign = require('../../models/campaign');
 const EmailDeployment = require('../../models/email-deployment');
+const EmailPlacement = require('../../models/email-placement');
 const Image = require('../../models/image');
 const Placement = require('../../models/placement');
 const Publisher = require('../../models/publisher');
@@ -31,6 +32,11 @@ module.exports = {
     emailDeployments: async (publisher, { pagination, sort }) => {
       const criteria = { publisherId: publisher.id, deleted: false };
       return EmailDeployment.paginate({ criteria, pagination, sort });
+    },
+    emailPlacements: async (publisher, { pagination, sort }) => {
+      const deploymentIds = EmailDeployment.distinct('_id', { publisherId: publisher.id, deleted: false });
+      const criteria = { deploymentId: { $in: deploymentIds }, deleted: false };
+      return EmailPlacement.paginate({ criteria, pagination, sort });
     },
     metrics: async (publisher, { start, end }) => {
       const pipeline = [];

--- a/src/graph/resolvers/publisher.js
+++ b/src/graph/resolvers/publisher.js
@@ -2,6 +2,7 @@ const { paginationResolvers } = require('@limit0/mongoose-graphql-pagination');
 const userAttributionFields = require('./user-attribution');
 const AnalyticsPlacement = require('../../models/analytics/placement');
 const Campaign = require('../../models/campaign');
+const EmailDeployment = require('../../models/email-deployment');
 const Image = require('../../models/image');
 const Placement = require('../../models/placement');
 const Publisher = require('../../models/publisher');
@@ -26,6 +27,10 @@ module.exports = {
       const placementIds = placements.map(placement => placement.id);
       const criteria = { 'criteria.placementIds': { $in: placementIds }, deleted: false };
       return Campaign.paginate({ criteria, pagination, sort });
+    },
+    emailDeployments: async (publisher, { pagination, sort }) => {
+      const criteria = { publisherId: publisher.id, deleted: false };
+      return EmailDeployment.paginate({ criteria, pagination, sort });
     },
     metrics: async (publisher, { start, end }) => {
       const pipeline = [];

--- a/src/models/email-deployment.js
+++ b/src/models/email-deployment.js
@@ -1,0 +1,4 @@
+const mongoose = require('../connections/mongoose/instance');
+const schema = require('../schema/email-deployment');
+
+module.exports = mongoose.model('email-deployment', schema);

--- a/src/models/email-line-item.js
+++ b/src/models/email-line-item.js
@@ -1,0 +1,4 @@
+const mongoose = require('../connections/mongoose/instance');
+const schema = require('../schema/email-deployment');
+
+module.exports = mongoose.model('email-line-item', schema);

--- a/src/models/email-line-item.js
+++ b/src/models/email-line-item.js
@@ -1,4 +1,4 @@
 const mongoose = require('../connections/mongoose/instance');
-const schema = require('../schema/email-deployment');
+const schema = require('../schema/email-line-item');
 
 module.exports = mongoose.model('email-line-item', schema);

--- a/src/models/email-placement.js
+++ b/src/models/email-placement.js
@@ -1,0 +1,4 @@
+const mongoose = require('../connections/mongoose/instance');
+const schema = require('../schema/email-placement');
+
+module.exports = mongoose.model('email-placement', schema);

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -7,6 +7,8 @@ const AnalyticsEvent = require('./analytics/event');
 const AnalyticsPlacement = require('./analytics/placement');
 const Campaign = require('./campaign');
 const Contact = require('./contact');
+const EmailDeployment = require('./email-deployment');
+const EmailPlacement = require('./email-placement');
 const Image = require('./image');
 const Placement = require('./placement');
 const Publisher = require('./publisher');
@@ -25,6 +27,8 @@ module.exports = {
   AnalyticsPlacement,
   Campaign,
   Contact,
+  EmailDeployment,
+  EmailPlacement,
   Image,
   Placement,
   Publisher,

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -8,6 +8,7 @@ const AnalyticsPlacement = require('./analytics/placement');
 const Campaign = require('./campaign');
 const Contact = require('./contact');
 const EmailDeployment = require('./email-deployment');
+const EmailLineItem = require('./email-line-item');
 const EmailPlacement = require('./email-placement');
 const Image = require('./image');
 const Placement = require('./placement');
@@ -28,6 +29,7 @@ module.exports = {
   Campaign,
   Contact,
   EmailDeployment,
+  EmailLineItem,
   EmailPlacement,
   Image,
   Placement,

--- a/src/plugins/deleteable.js
+++ b/src/plugins/deleteable.js
@@ -25,8 +25,8 @@ module.exports = function deleteablePlugin(schema, options = {}) {
     return doc;
   });
 
-  schema.static('findActiveById', function findActiveById(id, fields) {
-    return this.findOne({ _id: id || null, deleted: false }, fields);
+  schema.static('findActiveById', function findActiveById(id, fields, opts) {
+    return this.findOne({ _id: id || null, deleted: false }, fields, opts);
   });
 
   schema.static('strictFindActiveOne', async function strictFindActiveOne(criteria, fields) {

--- a/src/routers/email-placement.js
+++ b/src/routers/email-placement.js
@@ -1,0 +1,35 @@
+const { Router } = require('express');
+const helmet = require('helmet');
+const newrelic = require('../newrelic');
+const asyncRoute = require('../utils/async-route');
+const { parseOptions } = require('../services/campaign-delivery');
+const EmailLineItemDelivery = require('../services/email-line-item-delivery');
+
+const router = Router();
+router.use(helmet.noCache());
+
+router.get('/:pid([a-f0-9]{24}).json', asyncRoute(async (req, res) => {
+  const { pid } = req.params;
+  const { query } = req;
+  const { timestamp } = query;
+  // timezone offset handling must be handled by the requesting app
+  // all delivery is based on UTC time
+  let date = new Date();
+  const parsed = parseInt(timestamp, 10);
+  if (parsed) date = new Date(parsed);
+
+  const data = await EmailLineItemDelivery.findFor({
+    placementId: pid,
+    date,
+    imageOptions: parseOptions(query.imageOptions),
+    advertiserLogoOptions: parseOptions(query.advertiserLogoOptions),
+  });
+  res.json({ data });
+}), (err, req, res, next) => { // eslint-disable-line no-unused-vars
+  newrelic.noticeError(err);
+  const status = err.status || err.statusCode || 500;
+  const { message } = err;
+  res.status(status).json({ error: { status, message } });
+});
+
+module.exports = router;

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -1,10 +1,12 @@
 const graph = require('./graph');
+const emailPlacement = require('./email-placement');
 const placement = require('./placement');
 const event = require('./event');
 const upload = require('./upload');
 
 module.exports = (app) => {
   app.use('/graph', graph);
+  app.use('/email-placement', emailPlacement);
   app.use('/placement', placement);
   app.use('/e', event);
   app.use('/upload', upload);

--- a/src/schema/campaign/index.js
+++ b/src/schema/campaign/index.js
@@ -206,6 +206,11 @@ schema.pre('save', async function setReady() {
   }
 });
 
+schema.post('save', async function updateLineItems() {
+  const lineItems = await connection.model('email-line-item').find({ campaignId: this._id });
+  lineItems.forEach(lineItem => lineItem.save());
+});
+
 schema.index({ advertiserId: 1 });
 schema.index({ 'creatives.deleted': 1 });
 schema.index({ name: 1, _id: 1 }, { unique: true });

--- a/src/schema/email-deployment.js
+++ b/src/schema/email-deployment.js
@@ -57,13 +57,14 @@ schema.pre('save', async function setPublisherName() {
 });
 
 schema.pre('save', async function updateEmailPlacements() {
-  if (this.isModified('name')) {
+  if (this.isModified('name') || this.isModified('publisherName')) {
     // This isn't as efficient as calling `updateMany`, but the ElasticSearch
     // plugin will not fire properly otherwise.
     // As such, do not await the update.
     const EmailPlacement = connection.model('email-placement');
     const docs = await EmailPlacement.find({ deploymentId: this.id });
     docs.forEach((doc) => {
+      doc.set('publisherName', this.publisherName);
       doc.set('deploymentName', this.name);
       doc.save();
     });

--- a/src/schema/email-deployment.js
+++ b/src/schema/email-deployment.js
@@ -1,0 +1,79 @@
+const { Schema } = require('mongoose');
+const connection = require('../connections/mongoose/instance');
+const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
+const {
+  deleteablePlugin,
+  paginablePlugin,
+  referencePlugin,
+  repositoryPlugin,
+  searchablePlugin,
+  userAttributionPlugin,
+} = require('../plugins');
+
+const schema = new Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  publisherName: {
+    type: String,
+  },
+}, { timestamps: true });
+
+setEntityFields(schema, 'name');
+setEntityFields(schema, 'publisherName');
+applyElasticPlugin(schema, 'email-deployments');
+
+schema.plugin(referencePlugin, {
+  name: 'publisherId',
+  connection,
+  modelName: 'publisher',
+  options: { required: true },
+});
+schema.plugin(deleteablePlugin, {
+  es_indexed: true,
+  es_type: 'boolean',
+});
+schema.plugin(userAttributionPlugin);
+schema.plugin(repositoryPlugin);
+schema.plugin(paginablePlugin);
+schema.plugin(searchablePlugin, { fieldNames: ['name', 'publisherName'] });
+
+schema.pre('save', async function checkDelete() {
+  if (!this.isModified('deleted') || !this.deleted) return;
+
+  const [emailPlacements] = await Promise.all([
+    connection.model('email-placement').countActive({ publisherId: this.id }),
+  ]);
+  if (emailPlacements) throw new Error('You cannot delete an email deployment that has related placements.');
+});
+
+schema.pre('save', async function setPublisherName() {
+  if (this.isModified('publisherId') || !this.publisherName) {
+    const publisher = await connection.model('publisher').findOne({ _id: this.publisherId }, { name: 1 });
+    this.publisherName = publisher.name;
+  }
+});
+
+schema.pre('save', async function updateEmailPlacements() {
+  if (this.isModified('name')) {
+    // This isn't as efficient as calling `updateMany`, but the ElasticSearch
+    // plugin will not fire properly otherwise.
+    // As such, do not await the update.
+    const EmailPlacement = connection.model('email-placement');
+    const docs = await EmailPlacement.find({ deploymentId: this.id });
+    docs.forEach((doc) => {
+      doc.set('deploymentName', this.name);
+      doc.save();
+    });
+  }
+});
+
+schema.index({ publisherId: 1 });
+schema.index({ name: 1, _id: 1 }, { unique: true });
+schema.index({ name: -1, _id: -1 }, { unique: true });
+schema.index({ updatedAt: 1, _id: 1 }, { unique: true });
+schema.index({ updatedAt: -1, _id: -1 }, { unique: true });
+
+module.exports = schema;

--- a/src/schema/email-deployment.js
+++ b/src/schema/email-deployment.js
@@ -72,8 +72,6 @@ schema.pre('save', async function updateEmailPlacements() {
 
 schema.index({ publisherId: 1 });
 schema.index({ name: 1, _id: 1 }, { unique: true });
-schema.index({ name: -1, _id: -1 }, { unique: true });
 schema.index({ updatedAt: 1, _id: 1 }, { unique: true });
-schema.index({ updatedAt: -1, _id: -1 }, { unique: true });
 
 module.exports = schema;

--- a/src/schema/email-line-item.js
+++ b/src/schema/email-line-item.js
@@ -110,7 +110,7 @@ schema.method('getRequirements', async function getRequirements() {
   }
 
   const campaignNeeds = 'an active campaign with at least one active creative';
-  const campaign = await connection.model('campaign').findOne({ campaignId: this.campaignId, deleted: false });
+  const campaign = await connection.model('campaign').findOne({ _id: this.campaignId, deleted: false });
   if (campaign) {
     const activeCreatives = isArray(campaign.creatives)
       ? campaign.creatives.filter(cre => cre.active)

--- a/src/schema/email-line-item.js
+++ b/src/schema/email-line-item.js
@@ -28,6 +28,11 @@ const datesSchema = new Schema({
 });
 
 const schema = new Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+  },
   ready: {
     type: Boolean,
     default: false,
@@ -127,6 +132,7 @@ schema.pre('save', async function setReady() {
 
 schema.index({ campaignId: 1, emailPlacementId: 1 });
 schema.index({ emailPlacementId: 1 });
+schema.index({ name: 1, _id: 1 });
 schema.index({ updatedAt: 1, _id: 1 });
 
 module.exports = schema;

--- a/src/schema/email-line-item.js
+++ b/src/schema/email-line-item.js
@@ -133,6 +133,16 @@ schema.pre('save', async function setReady() {
 
 schema.index({ campaignId: 1, emailPlacementId: 1 });
 schema.index({ emailPlacementId: 1 });
+// for delivery
+schema.index({
+  'dates.days': 1,
+  'dates.start': 1,
+  'dates.end': 1,
+  emailPlacementId: 1,
+  ready: 1,
+  deleted: 1,
+  paused: 1,
+});
 schema.index({ name: 1, _id: 1 });
 schema.index({ updatedAt: 1, _id: 1 });
 

--- a/src/schema/email-line-item.js
+++ b/src/schema/email-line-item.js
@@ -24,6 +24,7 @@ const datesSchema = new Schema({
   },
   days: {
     type: [Date],
+    default: [],
   },
 });
 

--- a/src/schema/email-line-item.js
+++ b/src/schema/email-line-item.js
@@ -125,7 +125,7 @@ schema.pre('save', async function setReady() {
   }
 });
 
-schema.index({ campaignId: 1, emailPlacementId: 1 }, { unique: true });
+schema.index({ campaignId: 1, emailPlacementId: 1 });
 schema.index({ emailPlacementId: 1 });
 schema.index({ updatedAt: 1, _id: 1 });
 

--- a/src/schema/email-line-item.js
+++ b/src/schema/email-line-item.js
@@ -1,0 +1,132 @@
+const { Schema } = require('mongoose');
+const connection = require('../connections/mongoose/instance');
+const {
+  deleteablePlugin,
+  paginablePlugin,
+  referencePlugin,
+  repositoryPlugin,
+  userAttributionPlugin,
+} = require('../plugins');
+
+const { isArray } = Array;
+
+const datesSchema = new Schema({
+  type: {
+    type: String,
+    enum: ['range', 'days'],
+    default: 'days',
+  },
+  start: {
+    type: Date,
+  },
+  end: {
+    type: Date,
+  },
+  days: {
+    type: [Date],
+  },
+});
+
+const schema = new Schema({
+  ready: {
+    type: Boolean,
+    default: false,
+  },
+  paused: {
+    type: Boolean,
+    default: false,
+  },
+  dates: {
+    type: datesSchema,
+    default: () => ({}),
+  },
+}, { timestamps: true });
+
+schema.plugin(referencePlugin, {
+  name: 'emailPlacementId',
+  connection,
+  modelName: 'email-placement',
+  options: { required: true },
+});
+schema.plugin(referencePlugin, {
+  name: 'campaignId',
+  connection,
+  modelName: 'campaign',
+  options: { required: true },
+});
+schema.plugin(deleteablePlugin, {
+  es_indexed: true,
+  es_type: 'boolean',
+});
+schema.plugin(repositoryPlugin);
+schema.plugin(userAttributionPlugin);
+schema.plugin(paginablePlugin);
+
+schema.virtual('status').get(function getStatus() {
+  const { dates } = this;
+
+  const now = Date.now();
+  let newestDay;
+  let oldestDay;
+  if (dates.type === 'days') {
+    const days = isArray(dates.days) ? dates.days : [];
+    const times = days.map(d => d.valueOf()).sort();
+    [oldestDay] = times;
+    [newestDay] = times.reverse();
+  }
+
+  if (this.deleted) return 'Deleted';
+  if (dates.type === 'range' && dates.end && dates.end.valueOf() <= now) return 'Finished';
+  if (dates.type === 'days' && newestDay && newestDay.valueOf() <= now) return 'Finished';
+  if (!this.ready) return 'Incomplete';
+  if (this.paused) return 'Paused';
+  if (dates.type === 'range' && dates.start && dates.start.valueOf() <= now) return 'Running';
+  // @todo this should be changed to see if the current date is between days. If so, scheduled.
+  if (dates.type === 'days' && oldestDay && oldestDay.valueOf() <= now) return 'Running';
+  return 'Scheduled';
+});
+
+schema.method('getRequirements', async function getRequirements() {
+  const { dates } = this;
+  const needs = [];
+
+  const datesNeeds = 'a valid date range or selection of days';
+  switch (dates.type) {
+    case 'range':
+      if (!dates.start || !dates.end) needs.push(datesNeeds);
+      break;
+    case 'days':
+      if (!isArray(dates.days) || !dates.days.length) needs.push(datesNeeds);
+      break;
+    default:
+      needs.push(datesNeeds);
+      break;
+  }
+
+  const campaignNeeds = 'an active campaign with at least one active creative';
+  const campaign = await connection.model('campaign').findOne({ campaignId: this.campaignId, deleted: false });
+  if (campaign) {
+    const activeCreatives = isArray(campaign.creatives)
+      ? campaign.creatives.filter(cre => cre.active)
+      : [];
+    if (!activeCreatives.length) needs.push(campaignNeeds);
+  } else {
+    needs.push(campaignNeeds);
+  }
+  return needs.sort().join(', ');
+});
+
+schema.pre('save', async function setReady() {
+  const needs = await this.getRequirements();
+  if (needs.length) {
+    this.ready = false;
+  } else {
+    this.ready = true;
+  }
+});
+
+schema.index({ campaignId: 1, emailPlacementId: 1 }, { unique: true });
+schema.index({ emailPlacementId: 1 });
+schema.index({ updatedAt: 1, _id: 1 });
+
+module.exports = schema;

--- a/src/schema/email-placement.js
+++ b/src/schema/email-placement.js
@@ -68,7 +68,7 @@ schema.pre('save', async function checkDelete() {
   if (lineItems) throw new Error('You cannot delete a placement that has related email line items.');
 });
 
-schema.index({ deploymentId: 1 });
+schema.index({ deploymentId: 1, deleted: 1 });
 schema.index({ name: 1, _id: 1 }, { unique: true });
 schema.index({ updatedAt: 1, _id: 1 }, { unique: true });
 

--- a/src/schema/email-placement.js
+++ b/src/schema/email-placement.js
@@ -54,8 +54,6 @@ schema.pre('save', async function setDeploymentName() {
 
 schema.index({ deploymentId: 1 });
 schema.index({ name: 1, _id: 1 }, { unique: true });
-schema.index({ name: -1, _id: -1 }, { unique: true });
 schema.index({ updatedAt: 1, _id: 1 }, { unique: true });
-schema.index({ updatedAt: -1, _id: -1 }, { unique: true });
 
 module.exports = schema;

--- a/src/schema/email-placement.js
+++ b/src/schema/email-placement.js
@@ -15,12 +15,16 @@ const schema = new Schema({
     type: String,
     trim: true,
   },
+  publisherName: {
+    type: String,
+  },
   deploymentName: {
     type: String,
   },
 }, { timestamps: true });
 
 setEntityFields(schema, 'name');
+setEntityFields(schema, 'publisherName');
 setEntityFields(schema, 'deploymentName');
 applyElasticPlugin(schema, 'email-placements');
 
@@ -37,7 +41,7 @@ schema.plugin(deleteablePlugin, {
 schema.plugin(userAttributionPlugin);
 schema.plugin(repositoryPlugin);
 schema.plugin(paginablePlugin);
-schema.plugin(searchablePlugin, { fieldNames: ['name', 'deploymentName'] });
+schema.plugin(searchablePlugin, { fieldNames: ['name', 'publisherName', 'deploymentName'] });
 
 schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
@@ -49,6 +53,13 @@ schema.pre('save', async function setDeploymentName() {
   if (this.isModified('deploymentId') || !this.deploymentName) {
     const deployment = await connection.model('email-deployment').findOne({ _id: this.deploymentId }, { name: 1 });
     this.deploymentName = deployment.name;
+  }
+});
+
+schema.pre('save', async function setPublisherName() {
+  if (this.isModified('publisherId') || !this.publisherName) {
+    const deployment = await connection.model('email-deployment').findOne({ _id: this.deploymentId }, { publisherName: 1 });
+    this.publisherName = deployment.publisherName;
   }
 });
 

--- a/src/schema/email-placement.js
+++ b/src/schema/email-placement.js
@@ -41,8 +41,8 @@ schema.plugin(searchablePlugin, { fieldNames: ['name', 'deploymentName'] });
 
 schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
-  const campaigns = await connection.model('campaign').countActive({ 'emailCriteria.emailPlacementId': this.id });
-  if (campaigns) throw new Error('You cannot delete a placement that has related campaigns.');
+  const lineItems = await connection.model('email-line-item').countActive({ emailPlacementId: this.id });
+  if (lineItems) throw new Error('You cannot delete a placement that has related email line items.');
 });
 
 schema.pre('save', async function setDeploymentName() {

--- a/src/schema/email-placement.js
+++ b/src/schema/email-placement.js
@@ -1,0 +1,61 @@
+const { Schema } = require('mongoose');
+const connection = require('../connections/mongoose/instance');
+const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
+const {
+  deleteablePlugin,
+  paginablePlugin,
+  referencePlugin,
+  repositoryPlugin,
+  searchablePlugin,
+  userAttributionPlugin,
+} = require('../plugins');
+
+const schema = new Schema({
+  name: {
+    type: String,
+    trim: true,
+  },
+  deploymentName: {
+    type: String,
+  },
+}, { timestamps: true });
+
+setEntityFields(schema, 'name');
+setEntityFields(schema, 'deploymentName');
+applyElasticPlugin(schema, 'email-placements');
+
+schema.plugin(referencePlugin, {
+  name: 'deploymentId',
+  connection,
+  modelName: 'email-deployment',
+  options: { required: true },
+});
+schema.plugin(deleteablePlugin, {
+  es_indexed: true,
+  es_type: 'boolean',
+});
+schema.plugin(userAttributionPlugin);
+schema.plugin(repositoryPlugin);
+schema.plugin(paginablePlugin);
+schema.plugin(searchablePlugin, { fieldNames: ['name', 'deploymentName'] });
+
+schema.pre('save', async function checkDelete() {
+  if (!this.isModified('deleted') || !this.deleted) return;
+  const campaigns = await connection.model('campaign').countActive({ 'emailCriteria.emailPlacementId': this.id });
+  if (campaigns) throw new Error('You cannot delete a placement that has related campaigns.');
+});
+
+schema.pre('save', async function setDeploymentName() {
+  if (this.isModified('deploymentId') || !this.deploymentName) {
+    const deployment = await connection.model('email-deployment').findOne({ _id: this.deploymentId }, { name: 1 });
+    this.deploymentName = deployment.name;
+  }
+});
+
+schema.index({ deploymentId: 1 }, { unique: true });
+schema.index({ name: 1, _id: 1 }, { unique: true });
+schema.index({ name: -1, _id: -1 }, { unique: true });
+schema.index({ updatedAt: 1, _id: 1 }, { unique: true });
+schema.index({ updatedAt: -1, _id: -1 }, { unique: true });
+
+module.exports = schema;

--- a/src/schema/email-placement.js
+++ b/src/schema/email-placement.js
@@ -52,7 +52,7 @@ schema.pre('save', async function setDeploymentName() {
   }
 });
 
-schema.index({ deploymentId: 1 }, { unique: true });
+schema.index({ deploymentId: 1 });
 schema.index({ name: 1, _id: 1 }, { unique: true });
 schema.index({ name: -1, _id: -1 }, { unique: true });
 schema.index({ updatedAt: 1, _id: 1 }, { unique: true });

--- a/src/schema/email-placement.js
+++ b/src/schema/email-placement.js
@@ -13,6 +13,7 @@ const {
 const schema = new Schema({
   name: {
     type: String,
+    required: true,
     trim: true,
   },
   fullName: {

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -95,6 +95,20 @@ schema.pre('save', async function updatePlacements() {
   }
 });
 
+schema.pre('save', async function updateEmailDeployments() {
+  if (this.isModified('name')) {
+    // This isn't as efficient as calling `updateMany`, but the ElasticSearch
+    // plugin will not fire properly otherwise.
+    // As such, do not await the update.
+    const EmailDeployment = connection.model('email-deployment');
+    const docs = await EmailDeployment.find({ publisherId: this.id });
+    docs.forEach((doc) => {
+      doc.set('publisherName', this.name);
+      doc.save();
+    });
+  }
+});
+
 schema.pre('save', async function updateTopics() {
   if (this.isModified('name')) {
     // This isn't as efficient as calling `updateMany`, but the ElasticSearch

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -69,12 +69,16 @@ schema.plugin(searchablePlugin, { fieldNames: ['name'] });
 schema.pre('save', async function checkDelete() {
   if (!this.isModified('deleted') || !this.deleted) return;
 
-  const placements = await connection.model('placement').countActive({ publisherId: this.id });
+  const [placements, topics, stories, emailDeployments] = await Promise.all([
+    connection.model('placement').countActive({ publisherId: this.id }),
+    connection.model('topic').countActive({ publisherId: this.id }),
+    connection.model('story').countActive({ publisherId: this.id }),
+    connection.model('emailDeployment').countActive({ publisherId: this.id }),
+  ]);
   if (placements) throw new Error('You cannot delete a publisher that has related placements.');
-  const topics = await connection.model('topic').countActive({ publisherId: this.id });
   if (topics) throw new Error('You cannot delete a publisher that has related topics.');
-  const stories = await connection.model('story').countActive({ publisherId: this.id });
   if (stories) throw new Error('You cannot delete a publisher that has related stories.');
+  if (emailDeployments) throw new Error('You cannot delete a publisher that has related email deployments.');
 });
 
 schema.pre('save', async function updatePlacements() {

--- a/src/services/email-line-item-delivery.js
+++ b/src/services/email-line-item-delivery.js
@@ -1,0 +1,215 @@
+const createError = require('http-errors');
+const {
+  Advertiser,
+  Campaign,
+  EmailDeployment,
+  EmailLineItem,
+  EmailPlacement,
+  Image,
+  Publisher,
+  Story,
+} = require('../models');
+const storyUrl = require('../utils/story-url');
+const accountService = require('./account');
+const dayjs = require('../dayjs');
+
+const { isArray } = Array;
+
+const getStartOfDay = date => new Date(Date.UTC(
+  date.getFullYear(),
+  date.getMonth(),
+  date.getDate(),
+));
+
+module.exports = {
+  /**
+   *
+   * @param {object} params
+   * @param {string} params.placementId
+   * @param {Date} params.date
+   * @param {object} [params.imageOptions] Imgix options to use in the creative image url.
+   * @param {object} [params.advertiserLogoOptions] Imgix options to use in the creative image url.
+   */
+  async findFor({
+    placementId,
+    date,
+    imageOptions,
+    advertiserLogoOptions,
+  } = {}) {
+    const [placement, lineItem] = await Promise.all([
+      this.getPlacement({ placementId }),
+      this.getLineItemFor({ placementId, date }),
+    ]);
+    if (!lineItem) return null;
+
+    // find the campaign and for the line item and the deployment for the placement
+    const [campaign, deployment] = await Promise.all([
+      Campaign.findActiveById(lineItem.campaignId, {
+        name: 1,
+        advertiserId: 1,
+        storyId: 1,
+        url: 1,
+        creatives: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      }),
+      EmailDeployment.findById(placement.deploymentId, { publisherId: 1 }),
+    ]);
+    if (!campaign) return null;
+    const [advertiser, creative] = await Promise.all([
+      this.getAdvertiserFor(campaign, advertiserLogoOptions),
+      this.getCreativeFor(campaign),
+    ]);
+    if (!creative) return null;
+
+    await Promise.all([
+      (async () => {
+        if (creative.image) creative.image.src = await creative.image.getSrc(true, imageOptions);
+      })(),
+      (async () => {
+        if (advertiser.image) {
+          advertiser.image.src = await advertiser.image.getSrc(false, advertiserLogoOptions);
+        }
+      })(),
+    ]);
+
+    return {
+      placement: {
+        id: placement.id,
+        name: placement.name,
+        fullName: placement.fullName,
+        publisherName: placement.publisherName,
+        deploymentName: placement.deploymentName,
+      },
+      advertiser: {
+        id: advertiser.id,
+        name: advertiser.name,
+        pushId: advertiser.pushId,
+        website: advertiser.website,
+        externalId: advertiser.externalId,
+        image: advertiser.image ? {
+          id: advertiser.image.id,
+          src: advertiser.image.src,
+          alt: advertiser.image.alt,
+        } : {},
+      },
+      campaign: {
+        id: campaign.id,
+        name: campaign.name,
+        lineItem: {
+          id: lineItem.id,
+          name: lineItem.name,
+          createdAt: lineItem.createdAt ? lineItem.createdAt.getTime() : null,
+          updatedAt: lineItem.updatedAt ? lineItem.updatedAt.getTime() : null,
+        },
+      },
+      creative: {
+        id: creative.id,
+        title: creative.title,
+        teaser: creative.teaser,
+        href: await this.getClickUrl(campaign, deployment, creative),
+        image: creative.image ? {
+          id: creative.image.id,
+          src: creative.image.src,
+          alt: creative.image.alt,
+        } : {},
+      },
+    };
+  },
+
+  /**
+   *
+   * @param {object} params
+   * @param {string} params.placementId
+   */
+  async getPlacement({ placementId } = {}) {
+    if (!placementId) throw createError(400, 'No placement ID was provided.');
+
+    const placement = await EmailPlacement.findOne({ _id: placementId, deleted: false }, {
+      _id: 1,
+      name: 1,
+      fullName: 1,
+      publisherName: 1,
+      deploymentId: 1,
+      deploymentName: 1,
+    });
+    if (!placement) throw createError(404, `No email placement exists for ID '${placementId}'`);
+    return placement;
+  },
+
+  /**
+   *
+   * @param {object} params
+   * @param {string} params.placementId
+   * @param {Date} params.date
+   */
+  async getLineItemFor({ placementId, date: d } = {}) {
+    if (!placementId) throw createError(400, 'No placement ID was provided.');
+    if (!d) throw createError(400, 'No date was provided.');
+    const { $d: date } = dayjs(d).tz('UTC');
+
+    // find the _first_ matching line item. if more than one, pick the oldest (i.e. sort by _id).
+    return EmailLineItem.findOne({
+      $or: [
+        { 'dates.start': { $lte: date }, 'dates.end': { $gte: date } },
+        { 'dates.days': getStartOfDay(date) },
+      ],
+      emailPlacementId: placementId,
+      ready: true,
+      deleted: false,
+      paused: false,
+    }, {
+      name: 1,
+      campaignId: 1,
+      createdAt: 1,
+      updatedAt: 1,
+    }, { sort: { _id: 1 } });
+  },
+
+  /**
+   *
+   * @param {object} campaign
+   */
+  async getCreativeFor(campaign) {
+    const { creatives } = campaign;
+    if (!isArray(creatives) || !creatives.length) return null;
+
+    const eligible = creatives.filter(creative => !creative.deleted && creative.active);
+    // use first eligible creative.
+    const [creative] = eligible;
+    if (!creative) return null;
+
+    // Append the creative's image.
+    const { imageId } = creative;
+    if (imageId) creative.image = await Image.findById(imageId);
+    return creative;
+  },
+
+  async getClickUrl(campaign, deployment = {}, creative = {}) {
+    const { storyId, url } = campaign;
+    const { publisherId } = deployment;
+    if (!storyId) return url;
+    // Campaign is linked to a story, generate using publiser or account host.
+    const publisher = await Publisher.findById(publisherId, { domainName: 1 });
+    const account = await accountService.retrieve();
+    const story = await Story.findById(storyId, { body: 0 });
+    const path = await story.getPath();
+    return storyUrl(publisher.customUri || account.storyUri, path, {
+      pubid: publisher.id,
+      utm_source: 'NativeX',
+      utm_medium: 'email',
+      utm_campaign: campaign.id,
+      utm_term: deployment.id,
+      utm_content: creative.id,
+    });
+  },
+
+  async getAdvertiserFor(campaign) {
+    if (!campaign || !campaign.advertiserId) return {};
+    const advertiser = await Advertiser.findById(campaign.advertiserId, ['name', 'pushId', 'website', 'externalId', 'logoImageId']);
+    if (!advertiser) return {};
+    const { logoImageId } = advertiser;
+    if (logoImageId) advertiser.image = await Image.findById(logoImageId);
+    return advertiser;
+  },
+};

--- a/test/elastic/models.spec.js
+++ b/test/elastic/models.spec.js
@@ -12,6 +12,8 @@ describe('elastic/models', function() {
       'topic',
       'story',
       'user',
+      'email-deployment',
+      'email-placement',
     ].sort();
     const names = models.map(Model => Model.modelName);
     expect(names.sort()).to.deep.equal(expected);

--- a/test/routers/index.spec.js
+++ b/test/routers/index.spec.js
@@ -12,7 +12,7 @@ describe('routers/index', function() {
         routers.push({ path, router });
       }
     };
-    const expectedPaths = ['/graph', '/placement', '/e', '/upload'];
+    const expectedPaths = ['/graph', '/placement', '/e', '/upload', '/email-placement'];
 
     loadRouters(app);
     expect(routers.length).to.equal(expectedPaths.length);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1282,6 +1282,11 @@ dasherize@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dasherize/-/dasherize-2.0.0.tgz#6d809c9cd0cf7bb8952d80fc84fa13d47ddb1308"
 
+dayjs@^1.9.7:
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.7.tgz#4b260bb17dceed2d5f29038dfee03c65a6786fc0"
+  integrity sha512-IC877KBdMhBrCfBfJXHQlo0G8keZ0Opy7YIIq5QKtUbCuHMzim8S4PyiVK4YmihI3iOF9lhfUBW4AQWHTR5WHA==
+
 debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"


### PR DESCRIPTION
Allows campaigns to be scheduled to email deployments by email placement and day (or date range).

This does not affect how campaigns are delivered and handled on the website and is additive only.