### PR TITLE
Adjust impression reserve logic

### DIFF
--- a/src/graph/definitions/placement.graphql
+++ b/src/graph/definitions/placement.graphql
@@ -23,7 +23,7 @@ type Placement implements UserAttribution & Timestampable {
   publisher: Publisher!
   template: Template!
   topic: Topic
-  reservePct: Int!
+  reservePct: Int
   updatedAt: Date
   createdAt: Date
   createdBy: User!
@@ -82,5 +82,3 @@ input UpdatePlacementInput {
   id: String!
   payload: PlacementPayloadInput!
 }
-
-

--- a/src/plugins/reserve-pct.js
+++ b/src/plugins/reserve-pct.js
@@ -2,7 +2,7 @@ module.exports = function reservePctPlugin(schema) {
   schema.add({
     reservePct: {
       type: Number,
-      default: 0,
+      default: null,
       min: 0,
       max: 100,
     },

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -119,7 +119,7 @@ module.exports = {
   }) {
     const rp = parseInt(placement.get('reservePct'), 10);
     const ap = account.get('settings.reservePct');
-    const reservePct = (Number.isInteger(rp) ? rp : (ap || 0)) / 100;
+    const reservePct = (rp != null ? rp : (ap || 0)) / 100;
 
     const campaigns = Math.random() >= reservePct
       ? await this.queryCampaigns({

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -117,9 +117,9 @@ module.exports = {
     limit,
     keyValues,
   }) {
-    const rp = placement.get('reservePct');
+    const rp = parseInt(placement.get('reservePct'), 10);
     const ap = account.get('settings.reservePct');
-    const reservePct = (rp || ap || 0) / 100;
+    const reservePct = (Number.isInteger(rp) ? rp : (ap || 0)) / 100;
 
     const campaigns = Math.random() >= reservePct
       ? await this.queryCampaigns({


### PR DESCRIPTION
Placements are now allowed to specify an impression reserve of `0` and override the account default. The field is now nullable, and if null, will fall back to the account setting.

The previous behavior on create of a placement was to set reservePct to 0 to use the account defaults. When created, placements will now have a null value for the impression reserve, keeping the same default behavior.

This change will require a coordinated deployment with the fortnight-app repository, as well as modification to customer-specific placement settings:
- Null value where placement `reservePct: 0`
- PMMI: Update account default to 20%