### PR TITLE
Add support for external stories

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       ACCOUNT_KEY: ${ACCOUNT_KEY-dev-tenant}
       BASE_URI: localhost:8100
       DEBUG: ${DEBUG}
-      ELASTIC_HOST: http://elasticsearch:9200
+      ELASTIC_HOST: ${ELASTIC_HOST-http://elasticsearch:9200}
       ELASTIC_INDEX_RECREATE: ${ELASTIC_INDEX_RECREATE-false}
       MONGOOSE_DEBUG: ${MONGOOSE_DEBUG-false}
       MONGO_DSN: ${MONGO_DSN-mongodb://mongo:27017/fortnight}

--- a/src/graph/definitions/publisher.graphql
+++ b/src/graph/definitions/publisher.graphql
@@ -22,6 +22,7 @@ type Publisher implements UserAttribution & Timestampable {
   id: String!
   name: String!
   domainName: String
+  storyPath: String
   website: String!
   logo: Image
   topics(pagination: PaginationInput = {}, sort: TopicSortInput = {}): TopicConnection!

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -29,6 +29,17 @@ const schema = new Schema({
       message: 'Invalid domain name: {VALUE}',
     },
   },
+  storyPath: {
+    type: String,
+    trim: true,
+    validate: {
+      validator(v) {
+        return `${v}`.contains('{{story.id}}') || `${v}`.contains('{{ story.id }}');
+      },
+      message: 'Invalid publisher story path: {VALUE} must contain "{{story.id}}"',
+    },
+    default: '/story/{{ advertiser.slug }}/{{ story.slug }}/{{ story.id }}',
+  },
   website: {
     type: String,
     required: true,

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -34,7 +34,7 @@ const schema = new Schema({
     trim: true,
     validate: {
       validator(v) {
-        return `${v}`.includes('{{story.id}}') || `${v}`.includes('{{ story.id }}');
+        return /{{\s*story\.id\s*}}/.test(v);
       },
       message: 'Invalid publisher story path: {VALUE} must contain "{{story.id}}"',
     },

--- a/src/schema/publisher.js
+++ b/src/schema/publisher.js
@@ -34,7 +34,7 @@ const schema = new Schema({
     trim: true,
     validate: {
       validator(v) {
-        return `${v}`.contains('{{story.id}}') || `${v}`.contains('{{ story.id }}');
+        return `${v}`.includes('{{story.id}}') || `${v}`.includes('{{ story.id }}');
       },
       message: 'Invalid publisher story path: {VALUE} must contain "{{story.id}}"',
     },

--- a/src/schema/story.js
+++ b/src/schema/story.js
@@ -14,7 +14,6 @@ const {
   userAttributionPlugin,
 } = require('../plugins');
 const storyUrl = require('../utils/story-url');
-const accountService = require('../services/account');
 
 const schema = new Schema({
   title: {
@@ -112,9 +111,7 @@ schema.method('getPath', async function getPath() {
 });
 
 schema.method('getUrl', async function getUrl(params) {
-  const account = await accountService.retrieve();
-  const path = await this.getPath();
-  return storyUrl(account.storyUri, path, params);
+  return storyUrl(this, params);
 });
 
 schema.pre('save', async function checkDelete() {

--- a/src/schema/story.js
+++ b/src/schema/story.js
@@ -1,5 +1,6 @@
 const { Schema } = require('mongoose');
 const slug = require('slug');
+const handlebars = require('../handlebars');
 const connection = require('../connections/mongoose/instance');
 const { applyElasticPlugin, setEntityFields } = require('../elastic/mongoose');
 const {
@@ -102,8 +103,12 @@ schema.method('clone', async function clone(user) {
 });
 
 schema.method('getPath', async function getPath() {
-  const advertiser = await connection.model('advertiser').findById(this.advertiserId);
-  return `story/${advertiser.slug}/${this.slug}/${this.id}`;
+  const [advertiser, publisher] = await Promise.all([
+    connection.model('advertiser').findById(this.advertiserId),
+    connection.model('publisher').findById(this.publisherId),
+  ]);
+  const template = handlebars.compile(publisher.storyPath);
+  return template({ advertiser, publisher, story: this });
 });
 
 schema.method('getUrl', async function getUrl(params) {

--- a/src/schema/story.js
+++ b/src/schema/story.js
@@ -111,7 +111,8 @@ schema.method('getPath', async function getPath() {
 });
 
 schema.method('getUrl', async function getUrl(params) {
-  return storyUrl(this, params);
+  const publisher = await connection.model('publisher').findById(this.publisherId);
+  return storyUrl(this, publisher, params);
 });
 
 schema.pre('save', async function checkDelete() {

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -159,7 +159,7 @@ module.exports = {
     // Campaign is linked to a story, generate using publiser or account host.
     const publisher = await Publisher.findById(publisherId, { domainName: 1 });
     const story = await Story.findById(storyId, { body: 0 });
-    return storyUrl(story, {
+    return storyUrl(story, publisher, {
       pubid: publisher.id,
       utm_source: 'NativeX',
       utm_medium: 'banner',

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -158,10 +158,8 @@ module.exports = {
     if (!storyId) return url;
     // Campaign is linked to a story, generate using publiser or account host.
     const publisher = await Publisher.findById(publisherId, { domainName: 1 });
-    const account = await accountService.retrieve();
     const story = await Story.findById(storyId, { body: 0 });
-    const path = await story.getPath();
-    return storyUrl(publisher.customUri || account.storyUri, path, {
+    return storyUrl(story, {
       pubid: publisher.id,
       utm_source: 'NativeX',
       utm_medium: 'banner',

--- a/src/services/email-line-item-delivery.js
+++ b/src/services/email-line-item-delivery.js
@@ -10,7 +10,6 @@ const {
   Story,
 } = require('../models');
 const storyUrl = require('../utils/story-url');
-const accountService = require('./account');
 const dayjs = require('../dayjs');
 
 const { isArray } = Array;
@@ -191,10 +190,8 @@ module.exports = {
     if (!storyId) return url;
     // Campaign is linked to a story, generate using publiser or account host.
     const publisher = await Publisher.findById(publisherId, { domainName: 1 });
-    const account = await accountService.retrieve();
     const story = await Story.findById(storyId, { body: 0 });
-    const path = await story.getPath();
-    return storyUrl(publisher.customUri || account.storyUri, path, {
+    return storyUrl(story, {
       pubid: publisher.id,
       utm_source: 'NativeX',
       utm_medium: 'email',

--- a/src/services/email-line-item-delivery.js
+++ b/src/services/email-line-item-delivery.js
@@ -191,7 +191,7 @@ module.exports = {
     // Campaign is linked to a story, generate using publiser or account host.
     const publisher = await Publisher.findById(publisherId, { domainName: 1 });
     const story = await Story.findById(storyId, { body: 0 });
-    return storyUrl(story, {
+    return storyUrl(story, publisher, {
       pubid: publisher.id,
       utm_source: 'NativeX',
       utm_medium: 'email',

--- a/src/utils/story-url.js
+++ b/src/utils/story-url.js
@@ -1,15 +1,12 @@
 const querystring = require('querystring');
-const connection = require('../connections/mongoose/instance');
 const accountService = require('../services/account');
 
-module.exports = async (story, params) => {
+module.exports = async (story, publisher, params) => {
   const [
     account,
-    publisher,
     path,
   ] = await Promise.all([
     accountService.retrieve(),
-    connection.model('publisher').findById(story.publisherId),
     story.getPath(),
   ]);
   const uri = publisher.customUri || account.storyUri;

--- a/src/utils/story-url.js
+++ b/src/utils/story-url.js
@@ -1,6 +1,18 @@
 const querystring = require('querystring');
+const connection = require('../connections/mongoose/instance');
+const accountService = require('../services/account');
 
-module.exports = (uri, path, params) => {
+module.exports = async (story, params) => {
+  const [
+    account,
+    publisher,
+    path,
+  ] = await Promise.all([
+    accountService.retrieve(),
+    connection.model('publisher').findById(story.publisherId),
+    story.getPath(),
+  ]);
+  const uri = publisher.customUri || account.storyUri;
   const url = `${uri.replace(/\/+$/g, '')}/${path.replace(/^\/+/g, '').replace(/\/+$/g, '')}`;
   if (params && typeof params === 'object') {
     return `${url}/?${querystring.stringify(params)}`;

--- a/test/utils/story-url.spec.js
+++ b/test/utils/story-url.spec.js
@@ -1,23 +1,40 @@
 const storyUrl = require('../../src/utils/story-url');
+const accountService = require('../../src/services/account');
+
+const sandbox = sinon.createSandbox();
 
 describe('utils/story-url', function() {
+  beforeEach(function() {
+    sandbox.stub(accountService, 'retrieve').resolves({
+      storyUri: 'https://www.google.com',
+    });
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
   it('should export a function.', async function() {
     expect(storyUrl).to.be.a('function');
   });
   it('should apply the URI and path', async function() {
-    expect(storyUrl('https://www.google.com', 'foo/bar')).to.equal('https://www.google.com/foo/bar');
+    expect(storyUrl({}, {})).to.eventually.equal('https://www.google.com/foo/bar');
   });
   it('should strip slashes properly', async function() {
-    expect(storyUrl('https://www.google.com//', '//foo/bar/')).to.equal('https://www.google.com/foo/bar');
+    const publisher = {
+      domainName: 'www.google.com//',
+      storyPath: 'foo/bar//',
+    };
+    expect(storyUrl({}, publisher)).to.eventually.equal('https://www.google.com/foo/bar');
   });
   it('should set query parameters', async function() {
     const params = {
       foo: 'bar',
       baz: true,
-    }
-    expect(storyUrl('https://www.google.com', 'foo/bar//', params)).to.equal('https://www.google.com/foo/bar/?foo=bar&baz=true');
+    };
+    expect(storyUrl({}, {}, params)).to.eventually.equal('https://www.google.com/foo/bar/?foo=bar&baz=true');
   });
   it('should not set the parameters when `params` is not an object.', async function() {
-    expect(storyUrl('https://www.google.com', 'foo/bar', '1234')).to.equal('https://www.google.com/foo/bar');
+    expect(storyUrl({}, {}, '1234')).to.eventually.equal('https://www.google.com/foo/bar');
   });
 });


### PR DESCRIPTION
Adds `storyPath` field to `publisher` model schema. This field defaults to the existing `stories.*` URL pattern, but can be customized. To be utilized along with the custom `domainName` field, this field should be displayed to but cannot be modified by an end user.