### PR TITLE
Allow retrieval of 50 ads at a time.

### DIFF
--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -34,8 +34,8 @@ module.exports = {
   },
 
   parseLimit(num) {
-    const limit = num > 0 ? parseInt(num, 10) : 1;
-    if (limit > 10) throw createError(400, 'You cannot return more than 10 ads in one request.');
+    const limit = num > 0 ? parseInt(num, 50) : 1;
+    if (limit > 50) throw createError(400, 'You cannot return more than 50 ads in one request.');
     return limit;
   },
 

--- a/src/services/campaign-delivery.js
+++ b/src/services/campaign-delivery.js
@@ -34,7 +34,7 @@ module.exports = {
   },
 
   parseLimit(num) {
-    const limit = num > 0 ? parseInt(num, 50) : 1;
+    const limit = num > 0 ? parseInt(num, 10) : 1;
     if (limit > 50) throw createError(400, 'You cannot return more than 50 ads in one request.');
     return limit;
   },


### PR DESCRIPTION
This blocks more than 10 ads being returned at a time, unsure if there was a reason for this number being set to what it was, open to suggestions regarding if and how this should be changed.