### PR TITLE
Support returning multiple email line items

### DIFF
--- a/src/routers/email-placement.js
+++ b/src/routers/email-placement.js
@@ -23,6 +23,7 @@ router.get('/:pid([a-f0-9]{24}).json', asyncRoute(async (req, res) => {
     date,
     imageOptions: parseOptions(query.imageOptions),
     advertiserLogoOptions: parseOptions(query.advertiserLogoOptions),
+    opts: parseOptions(query.opts),
   });
   res.json({ data });
 }), (err, req, res, next) => { // eslint-disable-line no-unused-vars

--- a/src/services/email-line-item-delivery.js
+++ b/src/services/email-line-item-delivery.js
@@ -46,7 +46,7 @@ module.exports = {
     if (!lineItems || !lineItems.length) return null;
     const lineItemsToReturn = lineItems.slice(0, limit);
 
-    // find the campaigns and for the line items and the deployment for the placements
+    // find the campaigns for the line items and the deployment for the placements
     const campaigns = await Promise.all(
       lineItemsToReturn.map(lineItem => Campaign.findActiveById(lineItem.campaignId, {
         name: 1,

--- a/src/services/email-line-item-delivery.js
+++ b/src/services/email-line-item-delivery.js
@@ -67,15 +67,15 @@ module.exports = {
     if (!creatives || !creatives.length) return null;
 
     await Promise.all(creatives.map(async (creative) => {
-      if (creative.image && creative.image.src) {
+      if (creative.image) {
         // eslint-disable-next-line no-param-reassign
-        creative.image.src = await creative.image.src.getSrc(true, imageOptions);
+        creative.image.src = await creative.image.getSrc(true, imageOptions);
       }
     }));
     await Promise.all(advertisers.map(async (advertiser) => {
-      if (advertiser.image && advertiser.image.src) {
+      if (advertiser.image) {
         // eslint-disable-next-line no-param-reassign
-        advertiser.image.src = await advertiser.image.src.getSrc(true, imageOptions);
+        advertiser.image.src = await advertiser.image.getSrc(true, imageOptions);
       }
     }));
 


### PR DESCRIPTION
![Screenshot from 2023-05-01 11-47-00](https://user-images.githubusercontent.com/46794001/235490653-68b6018f-f2ee-4b17-9597-2be71ac8ffef.png)


This was changed in a manner where it should not be backwards breaking with existing implementations (as in if no query parameter is provided it will return a single object as opposed to an array of that single object) and the previously supported query string parameters have not been altered in any way

When no parameter provided:

![Screenshot from 2023-05-01 11-52-16](https://user-images.githubusercontent.com/46794001/235491309-2fc6a5ca-6d28-48b7-ad1a-c68471f09cbc.png)
