### PR TITLE
Add Mailto support for campaign URLs

### DIFF
--- a/src/schema/campaign/index.js
+++ b/src/schema/campaign/index.js
@@ -69,6 +69,9 @@ const schema = new Schema({
     validate: {
       validator(v) {
         if (!v) return true;
+        // check if the url starts with mailto: and has a valid email address after that.
+        if (validator.isEmail(v.toLowerCase().replace('mailto:', ''))) return true;
+
         return validator.isURL(v, {
           protocols: ['http', 'https'],
           require_protocol: true,


### PR DESCRIPTION
Adjust validattion check for url on campaign s to include a mailto: check by do the followin check

`validator.isEmail(v.toLowerCase().replace('mailto:', ‘’))`

<img width="1209" alt="Screen Shot 2023-06-13 at 8 39 25 AM" src="https://github.com/parameter1/fortnight-graph/assets/3845869/3ac6a6a7-1f61-46fd-a6e9-13a524d7b0d5">
