### PR TITLE
Remove trailing / from end of story url

### DIFF
--- a/src/utils/story-url.js
+++ b/src/utils/story-url.js
@@ -12,7 +12,7 @@ module.exports = async (story, publisher, params) => {
   const uri = publisher.customUri || account.storyUri;
   const url = `${uri.replace(/\/+$/g, '')}/${path.replace(/^\/+/g, '').replace(/\/+$/g, '')}`;
   if (params && typeof params === 'object') {
-    return `${url}/?${querystring.stringify(params)}`;
+    return `${url}?${querystring.stringify(params)}`;
   }
   return url;
 };

--- a/test/services/campaign-delivery.spec.js
+++ b/test/services/campaign-delivery.spec.js
@@ -64,12 +64,12 @@ describe('services/campaign-delivery', function() {
     });
     it('should return the account based URI', async function() {
       await expect(campaignDelivery.getClickUrl({ id: 'campaign-id', storyId: '1234' }, { id: 'placement-id', publisherId: '1234' }, { id: 'creative-id' }))
-        .to.eventually.equal('https://www.google.com/foo/bar/?pubid=1234&utm_source=NativeX&utm_medium=banner&utm_campaign=campaign-id&utm_term=placement-id&utm_content=creative-id')
+        .to.eventually.equal('https://www.google.com/foo/bar?pubid=1234&utm_source=NativeX&utm_medium=banner&utm_campaign=campaign-id&utm_term=placement-id&utm_content=creative-id')
       ;
     });
     it('should return the publisher based URI', async function() {
       await expect(campaignDelivery.getClickUrl({ id: 'campaign-id', storyId: '1234' }, { id: 'placement-id', publisherId: '5678' }, { id: 'creative-id' }))
-        .to.eventually.equal('https://www.msn.com/foo/bar/?pubid=5678&utm_source=NativeX&utm_medium=banner&utm_campaign=campaign-id&utm_term=placement-id&utm_content=creative-id')
+        .to.eventually.equal('https://www.msn.com/foo/bar?pubid=5678&utm_source=NativeX&utm_medium=banner&utm_campaign=campaign-id&utm_term=placement-id&utm_content=creative-id')
       ;
     });
   });

--- a/test/utils/story-url.spec.js
+++ b/test/utils/story-url.spec.js
@@ -32,7 +32,7 @@ describe('utils/story-url', function() {
       foo: 'bar',
       baz: true,
     };
-    expect(storyUrl({}, {}, params)).to.eventually.equal('https://www.google.com/foo/bar/?foo=bar&baz=true');
+    expect(storyUrl({}, {}, params)).to.eventually.equal('https://www.google.com/foo/bar?foo=bar&baz=true');
   });
   it('should not set the parameters when `params` is not an object.', async function() {
     expect(storyUrl({}, {}, '1234')).to.eventually.equal('https://www.google.com/foo/bar');


### PR DESCRIPTION
Update the story-url util to no longer ad the trailing / to the end of story urls.

This in conjunction with https://github.com/parameter1/mindful-cms/pull/109 & https://github.com/parameter1/base-cms/pull/814